### PR TITLE
feat:train simple-ddpm after training auto-encoder

### DIFF
--- a/contactgen/configs/default.yaml
+++ b/contactgen/configs/default.yaml
@@ -10,6 +10,7 @@ reg_coef: 0.0005
 log_every_epoch: 100
 snapshot_every_epoch: 1000
 n_epochs: 3000
+ddpm_n_epochs: 200
 robustkl: True
 # network
 latentD: 16

--- a/contactgen/model.py
+++ b/contactgen/model.py
@@ -114,11 +114,11 @@ class ContactGenModel(nn.Module):
                    'mean_part': z_part.mean, 'std_part': z_part.scale,
                    'mean_uv': z_uv.mean, 'std_uv': z_uv.scale}
         if self.contact_ddpm:
-            z_s_contact = self.contact_ddpm.sample(1, z_s_contact.shape, self.device)
+            z_s_contact = self.contact_ddpm.sample(obj_cond.shape[0], z_s_contact.shape, self.device)
         if self.part_ddpm:
-            z_s_part = self.part_ddpm.sample(1, z_s_part.shape, self.device)
+            z_s_part = self.part_ddpm.sample(obj_cond.shape[0], z_s_part.shape, self.device)
         if self.uv_ddpm:
-            z_s_uv = self.uv_ddpm.sample(1, z_s_uv.shape, self.device)    
+            z_s_uv = self.uv_ddpm.sample(obj_cond.shape[0], z_s_uv.shape, self.device)    
         contacts_pred, partition_pred, uv_pred = self.decode(z_s_contact, z_s_part, z_s_uv, obj_cond, partition_object)
 
         results.update({'contacts_object': contacts_pred,

--- a/contactgen/trainer.py
+++ b/contactgen/trainer.py
@@ -161,6 +161,10 @@ class Trainer:
 
     def evaluate(self):
         self.model.eval()
+        self.contact_ddpm.eval()
+        self.part_ddpm.eval()
+        self.uv_ddpm.eval()
+        
         eval_loss_dict_net = {}
         
         with torch.no_grad():
@@ -179,7 +183,7 @@ class Trainer:
         return eval_loss_dict_net
     
     def train_ddpm(self):
-        n_epochs = self.cfg.n_epochs
+        n_epochs = self.cfg.ddpm_n_epochs
         z_contact = torch.distributions.normal.Normal(self.latentSpace['mean_contact'], torch.exp(self.latentSpace['std_contact']))
         z_part = torch.distributions.normal.Normal(self.latentSpace['mean_part'], torch.exp(self.latentSpace['std_part']))
         z_uv = torch.distributions.normal.Normal(self.latentSpace['mean_uv'], torch.exp(self.latentSpace['std_uv']))

--- a/ddpm/simple_ddpm.py
+++ b/ddpm/simple_ddpm.py
@@ -1,0 +1,101 @@
+"""
+Adapted from: https://github.com/cloneofsimo/minDiffusion
+"""
+
+from typing import Dict, Tuple
+
+import torch
+import torch.nn as nn
+
+def ddpm_schedules(beta1: float, beta2: float, T: int) -> Dict[str, torch.Tensor]:
+    """
+    Returns pre-computed schedules for DDPM sampling, training process.
+    """
+    assert beta1 < beta2 < 1.0, "beta1 and beta2 must be in (0, 1)"
+
+    beta_t = (beta2 - beta1) * torch.arange(0, T + 1, dtype=torch.float32) / T + beta1
+    sqrt_beta_t = torch.sqrt(beta_t)
+    alpha_t = 1 - beta_t
+    log_alpha_t = torch.log(alpha_t)
+    alphabar_t = torch.cumsum(log_alpha_t, dim=0).exp()
+
+    sqrtab = torch.sqrt(alphabar_t)
+    oneover_sqrta = 1 / torch.sqrt(alpha_t)
+
+    sqrtmab = torch.sqrt(1 - alphabar_t)
+    mab_over_sqrtmab_inv = (1 - alpha_t) / sqrtmab
+
+    return {
+        "alpha_t": alpha_t,  # \alpha_t
+        "oneover_sqrta": oneover_sqrta,  # 1/\sqrt{\alpha_t}
+        "sqrt_beta_t": sqrt_beta_t,  # \sqrt{\beta_t}
+        "alphabar_t": alphabar_t,  # \bar{\alpha_t}
+        "sqrtab": sqrtab,  # \sqrt{\bar{\alpha_t}}
+        "sqrtmab": sqrtmab,  # \sqrt{1-\bar{\alpha_t}}
+        "mab_over_sqrtmab": mab_over_sqrtmab_inv,  # (1-\alpha_t)/\sqrt{1-\bar{\alpha_t}}
+    }
+
+class DummyEpsModel(nn.Module):
+    """
+    This should be unet-like, but let's don't think about the model too much :P
+    Basically, any universal R^n -> R^n model should work.
+    """
+
+    def __init__(self, input_dim: int) -> None:
+        super(DummyEpsModel, self).__init__()
+        self.fc = nn.Sequential(
+            nn.Linear(input_dim, 128),
+            nn.ReLU(),
+            nn.Linear(128, 256),
+            nn.ReLU(),
+            nn.Linear(256, 128),
+            nn.ReLU(),
+            nn.Linear(128, input_dim),
+        )
+
+    def forward(self, x, t) -> torch.Tensor:
+        x = self.fc(x)
+        return x  # Remove the channel dimension
+
+class DDPM(nn.Module):
+    def __init__(
+        self,
+        eps_model: nn.Module,
+        betas: Tuple[float, float],
+        n_T: int,
+        criterion: nn.Module = nn.MSELoss(),
+    ) -> None:
+        super(DDPM, self).__init__()
+        self.eps_model = eps_model
+
+        # register_buffer allows us to freely access these tensors by name. It helps device placement.
+        for k, v in ddpm_schedules(betas[0], betas[1], n_T).items():
+            self.register_buffer(k, v)
+
+        self.n_T = n_T
+        self.criterion = criterion
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch_size = x.shape[0]
+        _ts = torch.randint(1, self.n_T, (batch_size,)).to(x.device)
+        eps = torch.randn_like(x)
+
+        sqrtab_t = self.sqrtab[_ts]  # Shape: [batch_size]
+        sqrtmab_t = self.sqrtmab[_ts]  # Shape: [batch_size]
+
+        x_t = sqrtab_t.unsqueeze(1) * x + sqrtmab_t.unsqueeze(1) * eps
+        
+        return self.criterion(eps, self.eps_model(x_t, _ts.float() / self.n_T))
+
+    def sample(self, n_sample: int, size: Tuple[int, int], device: torch.device) -> torch.Tensor:
+        x_i = torch.randn(n_sample, size[1]).to(device)  # x_T ~ N(0, 1)
+
+        for i in range(self.n_T, 0, -1):
+            z = torch.randn(n_sample, size[1]).to(device) if i > 1 else 0
+            eps = self.eps_model(x_i, torch.full((n_sample,), i / self.n_T, device=device))
+            x_i = (
+                self.oneover_sqrta[i] * (x_i - eps * self.mab_over_sqrtmab[i])
+                + self.sqrt_beta_t[i] * z
+            )
+
+        return x_i


### PR DESCRIPTION
# Draft Changelog
Last update: 10 Sep 2024 6:22 pm

## Added
- adapted a simple DDPM from https://github.com/cloneofsimo/minDiffusion
  - modify its input shape to [batch_size, input_dim], and the corresponding noise/beta shape
  - replace conv layers with linear layers, so to lower complexity
- add `insert_ddpms` function in ContactGen model
- add the `train_ddpm` function in `trainer.py`
  -  after training the auto-encoder, record the fixed latent space
  - use samples from the latent space to train 3 DDPM, the samples are detached so as to prevent the backpropgation to the mean and std of normal distribution
  - the training loop of `train_ddpm` function are adapted from https://github.com/cloneofsimo/minDiffusion/blob/master/superminddpm.py

## Result
Trained auto-encoder for 10 epochs, then insert and train the ddpm.

the loss increased rapidly after inserting DDPM (the 10th epoch),  then drop to a minimum, finally the loss increases again

I will try to tune the model to decrease the loss in future pr.
<img width="1504" alt="螢幕截圖 2024-09-10 上午12 28 39" src="https://github.com/user-attachments/assets/00fb9da4-d04e-47d0-9e62-ccc7cd886e22">



